### PR TITLE
Add .NET 8.0 as target

### DIFF
--- a/src/LoadingIndicator.WinForms/LoadingIndicator.Winforms.csproj
+++ b/src/LoadingIndicator.WinForms/LoadingIndicator.Winforms.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Winforms, Loading, async, indicator, long, operation, windows.forms</PackageTags>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Title>LoadingIndicator.WinForms</Title>
-    <TargetFrameworks>net45;net5.0-windows;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net45;net5.0-windows;net6.0-windows;net8.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <IsPackable>true</IsPackable>

--- a/src/SampleApplication/SampleApplication.csproj
+++ b/src/SampleApplication/SampleApplication.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LoadingIndicator.Sample</RootNamespace>
     <AssemblyName>LoadingIndicator.Sample</AssemblyName>
-    <TargetFrameworks>net47;net5.0-windows;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net47;net5.0-windows;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <Copyright>Copyright ©  2021</Copyright>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
- Adds `net8.0-windows` to the `TargetFrameworks` property in `SampleApplication` and `LoadingIndicator.WinForms`.